### PR TITLE
fix: add dependencies to avoid tocken lockdown

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -14,7 +14,6 @@ resource "random_id" "instance_id" {
   byte_length = 4
 }
 
-
 data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket" "lacework_cloudtrail_bucket" {
@@ -274,6 +273,7 @@ resource "lacework_integration_aws_ct" "default" {
     aws_sns_topic_subscription.lacework_sns_topic_sub,
     aws_sqs_queue_policy.lacework_sqs_queue_policy,
     aws_iam_policy.cross_account_policy,
+    lacework_integration_aws_cfg.default,
     aws_cloudtrail.lacework_cloudtrail
   ]
 }

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -210,8 +210,8 @@ resource "lacework_integration_azure_cfg" "default" {
   name      = var.lacework_integration_config_name
   tenant_id = data.azurerm_subscription.primary.tenant_id
   credentials {
-      client_id     = azuread_application.default.application_id
-      client_secret = azuread_application_password.client_secret.value
+    client_id     = azuread_application.default.application_id
+    client_secret = azuread_application_password.client_secret.value
   }
   depends_on = [ azurerm_eventgrid_event_subscription.default ]
 }
@@ -221,8 +221,11 @@ resource "lacework_integration_azure_al" "default" {
   tenant_id = data.azurerm_subscription.primary.tenant_id
   queue_url = "https://${azurerm_storage_account.default.name}.queue.core.windows.net/${azurerm_storage_queue.default.name}"
   credentials {
-      client_id     = azuread_application.default.application_id
-      client_secret = azuread_application_password.client_secret.value
+    client_id     = azuread_application.default.application_id
+    client_secret = azuread_application_password.client_secret.value
   }
-  depends_on = [ azurerm_eventgrid_event_subscription.default ]
+  depends_on = [
+    azurerm_eventgrid_event_subscription.default,
+    lacework_integration_azure_cfg.default
+  ]
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -208,6 +208,7 @@ resource "lacework_integration_gcp_at" "default" {
   depends_on = [
     google_project_iam_member.project_viewer_binding,
     google_storage_notification.lacework_notification,
-    google_project_iam_member.project_security_reviewer_binding
+    google_project_iam_member.project_security_reviewer_binding,
+    lacework_integration_gcp_cfg.default
   ]
 }


### PR DESCRIPTION
We have a bug on the platform that if two token requests come at the
same time (~2ms difference) the platform will generate two tokens and
lockdown the API access key, to avoid that we are adding a dependency to
every lacework resource to call it one by one until we fix the bug in
the platform.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>