### PR TITLE
fix(aws): use SQS URL instead of ARN

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -155,7 +155,7 @@ resource "aws_iam_role_policy_attachment" "security_audit_iam_role_policy_attach
 }
 
 resource "aws_iam_policy" "cross_account_policy" {
-  name        = "lacework-cross-account-policy"
+  name        = var.cross_account_policy_name
   description = "A cross account policy to allow Lacework to pull config and cloudtrail"
 
   policy = <<EOF

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -264,7 +264,7 @@ resource "lacework_integration_aws_cfg" "default" {
 
 resource "lacework_integration_aws_ct" "default" {
   name      = var.lacework_integration_cloudtrail_name
-  queue_url = aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn
+  queue_url = aws_sqs_queue.lacework_cloudtrail_sqs_queue.id
   credentials {
       role_arn    = aws_iam_role.lacework_iam_role.arn
       external_id = var.external_id

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -68,6 +68,10 @@ variable "force_destroy_bucket" {
   default = false
 }
 
+variable "cross_account_policy_name" {
+  default = "lacework-cross-account-policy"
+}
+
 variable "lacework_aws_account_id" {
   default = "434813966438"
 }


### PR DESCRIPTION
Fixing a quick bug where we are using the `ARN` instead of the `URL` of the
SQS queue. Additionally, we are adding a `cross_account_policy_name` variable.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>