### PR TITLE
docs(gcp): fix TF_VAR prefix in README.md

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -40,8 +40,8 @@ lacework_integration_auditlog_name = "<NAME FOR THIS INTEGRATION>"
 or use environment variables to avoid hardcoding API keys and secrets.
 
 ```
-export TF_VARS_lacework_api_key=<THE API KEY FROM LACEWORK JSON FILE>
-export TF_VARS_lacework_api_secret=<THE API SECRET FROM LACEWORK JSON FILE>
+export TF_VAR_lacework_api_key=<THE API KEY FROM LACEWORK JSON FILE>
+export TF_VAR_lacework_api_secret=<THE API SECRET FROM LACEWORK JSON FILE>
 ```
  
 5. Run `terraform init`

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -88,6 +88,4 @@ variable "required_apis" {
     service_usage = "serviceusage.googleapis.com"
     containers = "container.googleapis.com"
   }
-  
 }
-


### PR DESCRIPTION
Terraform documentation says that the prefix is `TF_VAR` instead of `TF_VARS`,
this change updates the `README.md` to use such prefixes:

https://www.terraform.io/docs/commands/environment-variables.html#tf_var_name

Additionally, added a nitpick change to remove empty lines from `gcp/variables.tf`

![tenor-232668769](https://user-images.githubusercontent.com/5712253/83694617-9a9f0d80-a5b5-11ea-87bf-e4fb7ac43fc7.gif)
