### PR TITLE
chore(aws) rename enable_cloudtrail => use_existing_cloudtrail

### DIFF
--- a/aws/modules/cloudtrail/examples/existing-cloudtrail-iam-role/main.tf
+++ b/aws/modules/cloudtrail/examples/existing-cloudtrail-iam-role/main.tf
@@ -6,9 +6,9 @@ module "aws_cloudtrail" {
 	source = "../../"
 
 	# Use an existing CloudTrail
-	enable_cloudtrail    = false
-	bucket_name          = "lacework-ct-bucket-7bb591f4"
-	sns_topic_name       = "lacework-ct-sns-7bb591f4"
+	use_existing_cloudtrail    = true
+	bucket_name                = "lacework-ct-bucket-7bb591f4"
+	sns_topic_name             = "lacework-ct-sns-7bb591f4"
 
 	# Use an existing IAM role
 	use_existing_iam_role = true

--- a/aws/modules/cloudtrail/examples/existing-cloudtrail/main.tf
+++ b/aws/modules/cloudtrail/examples/existing-cloudtrail/main.tf
@@ -6,8 +6,8 @@ module "aws_cloudtrail" {
 	source = "../../"
 
 	# Use an existing CloudTrail
-	enable_cloudtrail    = false
-	bucket_name          = "lacework-ct-bucket-8805c0bf"
-	sns_topic_name       = "lacework-ct-sns-8805c0bf"
+	use_existing_cloudtrail    = true
+	bucket_name                = "lacework-ct-bucket-8805c0bf"
+	sns_topic_name             = "lacework-ct-sns-8805c0bf"
 }
 

--- a/aws/modules/cloudtrail/main.tf
+++ b/aws/modules/cloudtrail/main.tf
@@ -27,7 +27,7 @@ resource "aws_cloudtrail" "lacework_cloudtrail" {
 # we need the identity of the caller to get their account_id for the s3 bucket
 data "aws_caller_identity" "current" {}
 resource "aws_s3_bucket" "cloudtrail_bucket" {
-	count         = var.use_existing_cloudtrail ? 1 : 0
+	count         = var.use_existing_cloudtrail ? 0 : 1
 	bucket        = local.bucket_name
 	force_destroy = var.bucket_force_destroy
 	policy        = <<POLICY

--- a/aws/modules/cloudtrail/main.tf
+++ b/aws/modules/cloudtrail/main.tf
@@ -16,7 +16,7 @@ resource "random_id" "uniq" {
 }
 
 resource "aws_cloudtrail" "lacework_cloudtrail" {
-	count                 = var.enable_cloudtrail ? 1 : 0
+	count                 = var.use_existing_cloudtrail ? 1 : 0
 	name                  = var.cloudtrail_name
 	is_multi_region_trail = true
 	s3_bucket_name        = local.bucket_name
@@ -27,7 +27,7 @@ resource "aws_cloudtrail" "lacework_cloudtrail" {
 # we need the identity of the caller to get their account_id for the s3 bucket
 data "aws_caller_identity" "current" {}
 resource "aws_s3_bucket" "cloudtrail_bucket" {
-	count         = var.enable_cloudtrail ? 1 : 0
+	count         = var.use_existing_cloudtrail ? 1 : 0
 	bucket        = local.bucket_name
 	force_destroy = var.bucket_force_destroy
 	policy        = <<POLICY

--- a/aws/modules/cloudtrail/main.tf
+++ b/aws/modules/cloudtrail/main.tf
@@ -16,7 +16,7 @@ resource "random_id" "uniq" {
 }
 
 resource "aws_cloudtrail" "lacework_cloudtrail" {
-	count                 = var.use_existing_cloudtrail ? 1 : 0
+	count                 = var.use_existing_cloudtrail ? 0 : 1
 	name                  = var.cloudtrail_name
 	is_multi_region_trail = true
 	s3_bucket_name        = local.bucket_name

--- a/aws/modules/cloudtrail/variables.tf
+++ b/aws/modules/cloudtrail/variables.tf
@@ -46,10 +46,10 @@ variable "sqs_queue_name" {
 	default = ""
 }
 
-variable "enable_cloudtrail" {
+variable "use_existing_cloudtrail" {
 	type        = bool
-	default     = true
-	description = "Set this to false to use an existing cloudtrail"
+	default     = false
+	description = "Set this to true to use an existing cloudtrail. Default behavior enables new cloudtrail"
 }
 
 variable "cloudtrail_name" {


### PR DESCRIPTION
This update renames the `enable_cloudtrail` attribute to `use_existing_cloudtrail`

The default behavior now is setup `use_existing_cloudtrail = false` which enables cloudtrail on the account Terraform is be executed against. If a user wants to use an existing cloudtrail they will set the attribute to `use_existing_cloudtrail = true`. Examples have been updated to reflect this change...

```
provider "lacework" { }

provider "aws" { }

module "aws_cloudtrail" {
	source = "../../"

	# Use an existing CloudTrail
	use_existing_cloudtrail    = true
	bucket_name                = "lacework-ct-bucket-7bb591f4"
	sns_topic_name             = "lacework-ct-sns-7bb591f4"

	# Use an existing IAM role
	use_existing_iam_role = true
	iam_role_name         = "lacework_iam_role"
	iam_role_external_id  = "1GrDkEZV5VJ@=nLm"
}
```

This new behavior is consistent with the `use_existing_iam_role` attribute. 

Signed-off-by: Scott Ford <scott.ford@lacework.net>