### PR TITLE
feat(aws): consolidated cloudtrail + multitenancy

### DIFF
--- a/aws/modules/cloudtrail/examples/complete-cloudtrail/main.tf
+++ b/aws/modules/cloudtrail/examples/complete-cloudtrail/main.tf
@@ -3,5 +3,5 @@ provider "lacework" { }
 provider "aws" { }
 
 module "aws_cloudtrail" {
-	source = "../../"
+	source = "github.com/lacework/terraform-provisioning/aws/modules/cloudtrail"
 }

--- a/aws/modules/cloudtrail/examples/consolidated-cloudtrail-multiple-lacework-tenants/main.tf
+++ b/aws/modules/cloudtrail/examples/consolidated-cloudtrail-multiple-lacework-tenants/main.tf
@@ -1,0 +1,42 @@
+provider "lacework" {
+	alias = "main"
+}
+
+provider "aws" {
+	alias = "main"
+}
+
+variable "aws_accounts" {
+  type    = list(string)
+  default = [
+		"123456789011",
+		// ... list all accounts
+		"123456789019",
+	]
+}
+
+resource "aws_sqs_queue" "lw_ct_sqs_sub_accounts" {
+	provider = aws.main
+  count    = length(var.aws_accounts)
+	name     = "lw-ct-sqs-${var.aws_accounts[count.index]}"
+}
+
+module "main_cloudtrail" {
+	source    = "github.com/lacework/terraform-provisioning/aws/modules/cloudtrail"
+	providers = {
+		aws      = aws.main
+		lacework = lacework.main
+	}
+	consolidated_trail = true
+	sqs_queues         = aws_sqs_queue.lw_ct_sqs_sub_accounts.*.arn
+}
+
+resource "lacework_integration_aws_ct" "main" {
+	provider  = lacework.main
+	name      = "TF consolidated"
+	queue_url = aws_sqs_queue.lacework_ct_sqs_sub_accounts.0.id
+	credentials {
+		role_arn    = module.main_cloudtrail.iam_role_arn
+		external_id = module.main_cloudtrail.external_id
+	}
+}

--- a/aws/modules/cloudtrail/examples/consolidated-cloudtrail-multiple-lacework-tenants/sub_account.tf
+++ b/aws/modules/cloudtrail/examples/consolidated-cloudtrail-multiple-lacework-tenants/sub_account.tf
@@ -1,0 +1,26 @@
+provider "lacework" {
+	alias = "sub_tenant"
+}
+
+provider "aws" {
+	alias = "sub_account"
+}
+
+resource "aws_cloudtrail" "lw_sub_account_cloudtrail" {
+	provider              = aws.sub_account
+	name                  = "lacework-sub-trail"
+	is_multi_region_trail = true
+	s3_bucket_name        = module.main_cloudtrail.bucket_name
+	sns_topic_name        = module.main_cloudtrail.sns_arn
+}
+
+resource "lacework_integration_aws_ct" "sub_account" {
+	provider  = lacework.sub_tenant
+	name      = "TF consolidated"
+	queue_url = aws_sqs_queue.lw_ct_sqs_sub_accounts.1.id
+	credentials {
+		role_arn    = module.main_cloudtrail.iam_role_arn
+		external_id = module.main_cloudtrail.external_id
+	}
+	depends_on = [aws_cloudtrail.lw_sub_account_cloudtrail]
+}

--- a/aws/modules/cloudtrail/examples/consolidated-cloudtrail/main.tf
+++ b/aws/modules/cloudtrail/examples/consolidated-cloudtrail/main.tf
@@ -1,0 +1,28 @@
+provider "lacework" {
+	alias = "main"
+}
+
+provider "aws" {
+	alias = "main"
+}
+
+module "main_cloudtrail" {
+	source    = "github.com/lacework/terraform-provisioning/aws/modules/cloudtrail"
+	providers = {
+		aws      = aws.main
+		lacework = lacework.main
+	}
+	consolidated_trail = true
+}
+
+provider "aws" {
+	alias = "sub_account"
+}
+
+resource "aws_cloudtrail" "lw_sub_account_cloudtrail" {
+	provider              = aws.sub_account
+	name                  = "lacework-sub-trail"
+	is_multi_region_trail = true
+	s3_bucket_name        = module.main_cloudtrail.bucket_name
+	sns_topic_name        = module.main_cloudtrail.sns_arn
+}

--- a/aws/modules/cloudtrail/examples/existing-cloudtrail-iam-role/main.tf
+++ b/aws/modules/cloudtrail/examples/existing-cloudtrail-iam-role/main.tf
@@ -3,7 +3,7 @@ provider "lacework" { }
 provider "aws" { }
 
 module "aws_cloudtrail" {
-	source = "../../"
+	source = "github.com/lacework/terraform-provisioning/aws/modules/cloudtrail"
 
 	# Use an existing CloudTrail
 	use_existing_cloudtrail    = true

--- a/aws/modules/cloudtrail/examples/existing-cloudtrail/main.tf
+++ b/aws/modules/cloudtrail/examples/existing-cloudtrail/main.tf
@@ -3,7 +3,7 @@ provider "lacework" { }
 provider "aws" { }
 
 module "aws_cloudtrail" {
-	source = "../../"
+	source = "github.com/lacework/terraform-provisioning/aws/modules/cloudtrail"
 
 	# Use an existing CloudTrail
 	use_existing_cloudtrail    = true

--- a/aws/modules/cloudtrail/output.tf
+++ b/aws/modules/cloudtrail/output.tf
@@ -1,0 +1,29 @@
+output "bucket_name" {
+	value       = local.bucket_name
+	description = "S3 Bucket name"
+}
+
+output "sqs_name" {
+	value       = local.sqs_queue_name
+	description = "SQS Queue name"
+}
+
+output "sns_arn" {
+	value       = aws_sns_topic.lacework_cloudtrail_sns_topic.arn
+	description = "SNS Topic ARN"
+}
+
+output "external_id" {
+	value       = local.external_id
+	description = "The External ID configured into the IAM role"
+}
+
+output "iam_role_name" {
+	value       = local.iam_role_name
+	description = "IAM Role name"
+}
+
+output "iam_role_arn" {
+	value       = module.lacework_ct_iam_role.arn
+	description = "IAM Role ARN"
+}

--- a/aws/modules/cloudtrail/variables.tf
+++ b/aws/modules/cloudtrail/variables.tf
@@ -1,3 +1,9 @@
+variable "consolidated_trail" {
+	type        = bool
+	default     = false
+	description = "Set this to true to configure a consolidated cloudtrail"
+}
+
 variable "use_existing_iam_role" {
 	type        = bool
 	default     = false
@@ -60,6 +66,12 @@ variable "cloudtrail_name" {
 variable "cross_account_policy_name" {
 	type    = string
 	default = ""
+}
+
+variable "sqs_queues" {
+	type        = list(string)
+	default     = []
+	description = "List of SQS queues to configure in the Lacework cross-account policy"
 }
 
 variable "lacework_integration_name" {

--- a/aws/modules/config/output.tf
+++ b/aws/modules/config/output.tf
@@ -1,11 +1,14 @@
 output "external_id" {
-	value = module.lacework_cfg_iam_role.external_id
+	value       = module.lacework_cfg_iam_role.external_id
+	description = "The External ID configured into the IAM role"
 }
 
 output "iam_role_name" {
-	value = module.lacework_cfg_iam_role.name
+	value       = module.lacework_cfg_iam_role.name
+	description = "IAM Role name"
 }
 
 output "iam_role_arn" {
-	value = module.lacework_cfg_iam_role.arn
+	value       = module.lacework_cfg_iam_role.arn
+	description = "IAM Role ARN"
 }


### PR DESCRIPTION
Closes https://github.com/lacework/terraform-provisioning/issues/32

## Enable New Consolidated CloudTrail Configuration
This example enables a new Consolidated CloudTrail and IAM Role for Lacework,
then configures both integrations with Lacework, finally, it configures a new
CloudTrail in an AWS sub-account that points to the main CloudTrail.

```hcl
provider "lacework" {
  alias = "main"
}

provider "aws" {
  alias = "main"
}

module "main_cloudtrail" {
  source    = "github.com/lacework/terraform-provisioning/aws/modules/cloudtrail"
  providers = {
    aws      = aws.main
    lacework = lacework.main
  }
  consolidated_trail = true
}

provider "aws" {
  alias = "sub_account"
}

resource "aws_cloudtrail" "lw_sub_account_cloudtrail" {
  provider              = aws.sub_account
  name                  = "lacework-sub-trail"
  is_multi_region_trail = true
  s3_bucket_name        = module.main_cloudtrail.bucket_name
  sns_topic_name        = module.main_cloudtrail.sns_arn
}
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>