### PR TITLE
chore(aws): expose cloudtrail SQS ARN

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -159,7 +159,8 @@ resource "aws_cloudtrail" "lw_sub_account_cloudtrail" {
 |------|-------------|
 | external_id | Dynamically generated External ID configured into the IAM role |
 | iam_role_name | IAM Role name generated |
-| iam_role_arn | IAM Role arn |
+| iam_role_arn | IAM Role ARN |
 | bucket_name | S3 Bucket name |
 | sqs_name | SQS Queue name |
-| sns_arn | SNS Topic Arn |
+| sqs_arn | SQS Queue ARN |
+| sns_arn | SNS Topic ARN |

--- a/aws/modules/cloudtrail/output.tf
+++ b/aws/modules/cloudtrail/output.tf
@@ -8,6 +8,11 @@ output "sqs_name" {
 	description = "SQS Queue name"
 }
 
+output "sqs_arn" {
+	value       = aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn
+	description = "SQS Queue ARN"
+}
+
 output "sns_arn" {
 	value       = aws_sns_topic.lacework_cloudtrail_sns_topic.arn
 	description = "SNS Topic ARN"


### PR DESCRIPTION
This will avoid users to use a `aws_sqs_queue` data source to get the SQS ARN if they need it.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>