### PR TITLE
fix(gcp): activate required apis correctly

### DIFF
--- a/gcp/modules/audit_log/variables.tf
+++ b/gcp/modules/audit_log/variables.tf
@@ -7,8 +7,6 @@ variable "required_apis" {
 	  logging           = "logging.googleapis.com"
 	  containers        = "container.googleapis.com"
 	  monitoring        = "monitoring.googleapis.com"
-	  service_usage     = "serviceusage.googleapis.com"
-	  resource_manager  = "cloudresourcemanager.googleapis.com"
 	  storage_component = "storage-component.googleapis.com"
 	}
 }

--- a/gcp/modules/service_account/variables.tf
+++ b/gcp/modules/service_account/variables.tf
@@ -1,7 +1,9 @@
 variable "required_apis" {
 	type = map
 	default = {
-	  iam = "iam.googleapis.com"
+	  iam             = "iam.googleapis.com"
+	  serviceusage    = "serviceusage.googleapis.com"
+	  resourcemanager = "cloudresourcemanager.googleapis.com"
 	}
 }
 


### PR DESCRIPTION
When doing some deep testing of the GCP modules, one use-case we have seen
with our customers is the **creation of a new GCP project that needs to be linked
to their Lacework account to be monitored right after its creation.** For example:
```hcl
provider "google" {}

provider "lacework" {}

resource "google_project" "new" {
	name       = "new-project"
	project_id = "project-123"
	org_id     = "1234567890"
}

module "new_project_gcp_config" {
	source     = "git::https://github.com/lacework/terraform-provisioning.git//gcp/modules/config"
	project_id = google_project.new.id
}
```

The above example will create a new Google Cloud project and configure it to
be monitored by Lacework.

This scenario requires the `service_account` module to have the following APIs enabled:
* serviceusage.googleapis.com
* cloudresourcemanager.googleapis.com

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>