### PR TITLE
docs(aws): Fixed typos and corrected main.tf example

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -2,16 +2,16 @@
 Terraform modules that create AWS resources required to integrate AWS accounts with the Lacework Cloud Security Platform.
 
 ## AWS Config and CloudTrail Integration Overview
-In order for Lacework to monitor AWS configuration and CloudTrail activity, the following must be configured your AWS account: 
+In order for Lacework to monitor AWS configuration and CloudTrail activity, the following must be configured for each AWS account:
 
 #### Required Resources
-- **Cross Account IAM Role** - Delegate access to Lacework to monitor resource configurations within customer's AWS account. This role is used for both the Config and CloudTrail
-  - `SecurityAudit` Policy - AWS managed policy to allow Lacework to assess configuration. Policy is applied for configuration assessment only.
-  - Custom IAM Policy - Delegate access to Lacework to monitor CloudTrail Activity. Policy is attached to the IAM role when for CloudTrail is configured.
-- **CloudTrail** - Enable a new CloudTrail or use an existing
-  - **S3 Bucket** - Used to store CloudTrail logs. Create a new S3 bucket, or use an existing
-  - **SNS Topic** - Used to send notifications when CloudTrail publishes new log files to the configured S3 bucket. Use existing or create a new SNS topic.
-  - **SQS Queue** - SQS queue subscribed to CloudTrail SNS topic for Lacework  
+- **Cross Account IAM Role** - Delegate access to Lacework to monitor resource configurations within customer's AWS account. This role is used for both the Config and CloudTrail Integrations
+  - `SecurityAudit` Policy - AWS managed policy used to allow Lacework to assess configuration metadata. Policy is applied for configuration assessment only.
+  - Custom IAM Policy - Delegate access to Lacework to monitor CloudTrail Activity. Policy is attached to the IAM role when CloudTrail is configured.
+- **CloudTrail** - Create a new CloudTrail Trail or use an existing Trail
+  - **S3 Bucket** - Used to store CloudTrail logs. Create a new S3 bucket, or use an existing bucket
+  - **SNS Topic** - Used to send notifications when CloudTrail publishes new log files to the configured S3 bucket. Use an existing or create a new SNS topic.
+  - **SQS Queue** - SQS queue subscribed to CloudTrail SNS topic used by Lacework to ingest CloudTrail logs
 - **Lacework AWS CFG Integration** - Configures AWS CFG integration between Lacework and customer AWS account
 - **Lacework AWS CT Integration** - Configures AWS CT integration between Lacework and customer AWS account
 
@@ -22,10 +22,14 @@ Before you begin the following must be configured on the workstation running Ter
 - [AWS API Access Key, Secret Access Key](https://aws.amazon.com/premiumsupport/knowledge-center/create-access-key/)
 - [Lacework API Key](https://support.lacework.com/hc/en-us/articles/360011403853-Generate-API-Access-Keys-and-Tokens)
 
+Typically, the [AWS CLI](https://aws.amazon.com/cli/) will have been previously installed and `aws configure` run and with `$AWS_PROFILE` set to the appropriate credential profile in `~/.aws/credentials`
+
+Also recommend that the [Lacework CLI](https://github.com/lacework/go-sdk) be installed and the `[default]` profile is associated with the applicable Lacework Account `api_key` and `api_secret` in `~/.lacework.toml`
+
 ## Usage
 
 ### Enable New CloudTrail Configuration
-This example enables a new CloudTrail, IAM Role for Lacework, and then configures both integrations with Lacework
+This example creates a new CloudTrail Trail, an IAM Role for Lacework, and then configures both integrations with Lacework
 
 ```hcl
 provider "aws" {}
@@ -45,8 +49,8 @@ module "aws_cloudtrail" {
 }
 ```
 
-### Integrate Existing CloudTrail Without SNS Delivey with Lacework
-This example uses an existing CloudTrail and S3 bucket passed as inputs to the module. The example creates the SNS topic, SQS queue, and IAM Role for Lacework, and then configures both integrations with Lacework.
+### Integrate Existing CloudTrail Without SNS Delivery with Lacework
+This example uses an existing CloudTrail Trail and S3 bucket passed as inputs to the module. The example creates the SNS topic, SQS queue, and IAM Role for Lacework, and then configures both integrations with Lacework.
 ```hcl
 provider "aws" {}
 
@@ -72,7 +76,7 @@ module "aws_cloudtrail" {
 
 ![](img/cloudtrail_enable_sns_delivery_notifications.gif)
 
-### Integrate Existing CloudTrail With SNS Delivey Enabled with Lacework
+### Integrate Existing CloudTrail With SNS Delivery Enabled with Lacework
 This example uses an existing CloudTrail, S3 bucket, and SNS topic passed as inputs to the module. The example creates the SQS queue and IAM Role for Lacework, and then configures both integrations with Lacework.
 ```hcl
 provider "aws" {}
@@ -99,8 +103,8 @@ module "aws_cloudtrail" {
 **NOTE: This example assumes that your CloudTrail is already sending delivery notifications to the provided SNS topic.**
 
 ### Enable New Consolidated CloudTrail Configuration
-This example enables a new Consolidated CloudTrail and IAM Role for Lacework, then configures both integrations with Lacework,
-finally, it configures a new CloudTrail in an AWS sub-account that points to the main CloudTrail.
+This example enables a new Consolidated CloudTrail and IAM Role for Lacework, then configures both integrations with Lacework.
+Finally, it configures a new CloudTrail Trail in an AWS sub-account that points to the main CloudTrail.
 
 ```hcl
 provider "lacework" {

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -3,11 +3,11 @@ provider "aws" {}
 provider "lacework" {}
 
 module "aws_config" {
-	source = "https://github.com/lacework/terraform-provisioning/aws/modules/config"
+	source = "github.com/lacework/terraform-provisioning/aws/modules/config"
 }
 
 module "aws_cloudtrail" {
-	source                = "https://github.com/lacework/terraform-provisioning/aws/modules/cloudtrail"
+	source                = "github.com/lacework/terraform-provisioning/aws/modules/cloudtrail"
 	bucket_force_destroy  = true
 	use_existing_iam_role = true
 	iam_role_name         = module.aws_config.iam_role_name


### PR DESCRIPTION
original main.tf example produced following error when terraform init was executed:

`$ terraform init
Initializing modules...
Downloading https://github.com/lacework/terraform-provisioning/aws/modules/cloudtrail for aws_cloudtrail...
Downloading https://github.com/lacework/terraform-provisioning/aws/modules/config for aws_config...
Error: Failed to download module`

Removed leading "https://"

Also minor edits to readme to improve readability.
