### PR TITLE
feat(aws): parameterize time_sleep duration with input wait_time

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -162,6 +162,7 @@ resource "aws_cloudtrail" "lw_sub_account_cloudtrail" {
 | consolidated_trail | Set this to `true` to configure a consolidated cloudtrail. | `bool` | `false` | no |
 | use_existing_cloudtrail | Set this to `true` to use an existing cloudtrail. When set to `true` you must provide both the `bucket_name` and `sns_topic_name` | `bool` | `false` | no |
 | use_existing_iam_role | Set this to `true` to use an existing IAM role. When set to `true` you must provide both the `iam_role_name` and `iam_role_external_id` | `bool` | `false` | no |
+| wait_time | Define a custom delay between cloud resource provision and Lacework external integration to avoid errors while things settle down. Use `10s` for 10 seconds, `5m` for 5 minutes. | `string` | `10s` | no |
 
 ## Outputs
 

--- a/aws/modules/cloudtrail/main.tf
+++ b/aws/modules/cloudtrail/main.tf
@@ -290,10 +290,10 @@ resource "aws_iam_role_policy_attachment" "lacework_cross_account_iam_role_polic
 	policy_arn = aws_iam_policy.cross_account_policy.arn 
 }
 
-# wait for 5 seconds for things to settle down in the AWS side
+# wait for X seconds for things to settle down in the AWS side
 # before trying to create the Lacework external integration
-resource "time_sleep" "wait_5_seconds" {
-	create_duration = "5s"
+resource "time_sleep" "wait_time" {
+	create_duration = var.wait_time
 	depends_on      = [
 		aws_iam_role_policy_attachment.lacework_cross_account_iam_role_policy,
 		aws_sns_topic_subscription.lacework_sns_topic_sub,
@@ -312,5 +312,5 @@ resource "lacework_integration_aws_ct" "default" {
 		role_arn    = module.lacework_ct_iam_role.arn
 		external_id = local.external_id
 	}
-	depends_on = [time_sleep.wait_5_seconds]
+	depends_on = [time_sleep.wait_time]
 }

--- a/aws/modules/cloudtrail/variables.tf
+++ b/aws/modules/cloudtrail/variables.tf
@@ -119,6 +119,6 @@ variable "lacework_aws_account_id" {
 
 variable "wait_time" {
 	type = string
-	default = "5s"
+	default = "10s"
 	description = "Amount of time to wait before the next resource is provisioned."
 }

--- a/aws/modules/cloudtrail/variables.tf
+++ b/aws/modules/cloudtrail/variables.tf
@@ -116,3 +116,9 @@ variable "lacework_aws_account_id" {
 	default     = "434813966438"
 	description = "The Lacework AWS account that the IAM role will grant access"
 }
+
+variable "wait_time" {
+	type = string
+	default = "5s"
+	description = "Amount of time to wait before the next resource is provisioned."
+}

--- a/aws/modules/config/main.tf
+++ b/aws/modules/config/main.tf
@@ -11,10 +11,10 @@ resource "aws_iam_role_policy_attachment" "security_audit_policy_attachment" {
 	depends_on = [module.lacework_cfg_iam_role]
 }
 
-# wait for 5 seconds for things to settle down in the AWS side
+# wait for X seconds for things to settle down in the AWS side
 # before trying to create the Lacework external integration
-resource "time_sleep" "wait_5_seconds" {
-	create_duration = "5s"
+resource "time_sleep" "wait_time" {
+	create_duration = var.wait_time
 	depends_on      = [aws_iam_role_policy_attachment.security_audit_policy_attachment]
 }
 
@@ -24,5 +24,5 @@ resource "lacework_integration_aws_cfg" "default" {
 		role_arn    = module.lacework_cfg_iam_role.arn
 		external_id = module.lacework_cfg_iam_role.external_id
 	}
-	depends_on = [time_sleep.wait_5_seconds]
+	depends_on = [time_sleep.wait_time]
 }

--- a/aws/modules/config/variables.tf
+++ b/aws/modules/config/variables.tf
@@ -20,3 +20,9 @@ variable "external_id_length" {
 	default     = 16
 	description = "The length of the external ID to generate. Max length is 1224"
 }
+
+variable "wait_time" {
+	type = string
+	default = "5s"
+	description = "Amount of time to wait before the next resource is provisioned."
+}

--- a/aws/modules/config/variables.tf
+++ b/aws/modules/config/variables.tf
@@ -23,6 +23,6 @@ variable "external_id_length" {
 
 variable "wait_time" {
 	type = string
-	default = "5s"
+	default = "10s"
 	description = "Amount of time to wait before the next resource is provisioned."
 }

--- a/aws/modules/iam_role/main.tf
+++ b/aws/modules/iam_role/main.tf
@@ -27,9 +27,9 @@ resource "aws_iam_role" "lacework_iam_role" {
 	assume_role_policy = data.aws_iam_policy_document.lacework_assume_role_policy.json
 }
 
-# wait for 5 seconds for the role to be created before trying to query it
-resource "time_sleep" "wait_5_seconds" {
-	create_duration = "5s"
+# wait for X seconds for the role to be created before trying to query it
+resource "time_sleep" "wait_time" {
+	create_duration = var.wait_time
 	depends_on      = [aws_iam_role.lacework_iam_role]
 }
 
@@ -37,5 +37,5 @@ resource "time_sleep" "wait_5_seconds" {
 # or the provided IAM Role name if the user decides not to create it
 data "aws_iam_role" "selected" {
 	name       = var.iam_role_name
-	depends_on = [time_sleep.wait_5_seconds]
+	depends_on = [time_sleep.wait_time]
 }

--- a/aws/modules/iam_role/variables.tf
+++ b/aws/modules/iam_role/variables.tf
@@ -21,3 +21,9 @@ variable "create" {
 	default     = true
 	description = "Set to false to prevent the module from creating any resources"
 }
+
+variable "wait_time" {
+	type = string
+	default = "5s"
+	description = "Amount of time to wait before the next resource is provisioned."
+}

--- a/aws/modules/iam_role/variables.tf
+++ b/aws/modules/iam_role/variables.tf
@@ -24,6 +24,6 @@ variable "create" {
 
 variable "wait_time" {
 	type = string
-	default = "5s"
+	default = "10s"
 	description = "Amount of time to wait before the next resource is provisioned."
 }

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -98,6 +98,7 @@ More information on adding GCP credentials for Terraform can be found [here](htt
 | bucket_force_destroy | Force destroy storage bucket (Required when bucket not empty) | `bool` | false | no |
 | existing_bucket_name | The name of an existing bucket you want to send the logs to | `string` | "" | no |
 | lacework_integration_name | The name of the integration in Lacework. This input is available in both the config, and the audit_log module | `string` | TF config | no |
+| wait_time | Define a custom delay between cloud resource provision and Lacework external integration to avoid errors while things settle down. Use `10s` for 10 seconds, `5m` for 5 minutes. | `string` | `10s` | no |
 
 ## Outputs
 

--- a/gcp/modules/audit_log/main.tf
+++ b/gcp/modules/audit_log/main.tf
@@ -126,10 +126,10 @@ resource "google_storage_notification" "lacework_notification" {
 	]
 }
 
-# wait for 5 seconds for things to settle down in the GCP side
+# wait for X seconds for things to settle down in the GCP side
 # before trying to create the Lacework external integration
-resource "time_sleep" "wait_10_seconds" {
-	create_duration = "10s"
+resource "time_sleep" "wait_time" {
+	create_duration = var.wait_time
 	depends_on      = [
 		google_storage_notification.lacework_notification,
 		google_pubsub_subscription_iam_binding.lacework,
@@ -148,5 +148,5 @@ resource "lacework_integration_gcp_at" "default" {
 		client_email   = local.service_account_json_key.client_email
 		private_key    = local.service_account_json_key.private_key
 	}
-	depends_on = [time_sleep.wait_10_seconds]
+	depends_on = [time_sleep.wait_time]
 }

--- a/gcp/modules/audit_log/variables.tf
+++ b/gcp/modules/audit_log/variables.tf
@@ -68,3 +68,9 @@ variable "lacework_integration_name" {
 	type    = string
 	default = "TF audit_log"
 }
+
+variable "wait_time" {
+	type = string
+	default = "10s"
+	description = "Amount of time to wait before the next resource is provisioned."
+}


### PR DESCRIPTION
Parameterize the create_duration parameter for time_sleep resources. 

Closes https://github.com/lacework/terraform-provisioning/issues/61