### PR TITLE
docs(gcp): add support docs link about required APIs

### DIFF
--- a/gcp/modules/audit_log/variables.tf
+++ b/gcp/modules/audit_log/variables.tf
@@ -1,3 +1,5 @@
+# All these API are required by Lacework:
+# => https://support.lacework.com/hc/en-us/articles/360034310713-Enable-the-Required-GCP-APIs
 variable "required_apis" {
   type = map
   default = {

--- a/gcp/modules/service_account/variables.tf
+++ b/gcp/modules/service_account/variables.tf
@@ -1,3 +1,5 @@
+# All these API are required by Lacework:
+# => https://support.lacework.com/hc/en-us/articles/360034310713-Enable-the-Required-GCP-APIs
 variable "required_apis" {
   type = map
   default = {


### PR DESCRIPTION
Adds comments that point to our documentation: https://support.lacework.com/hc/en-us/articles/360034310713-Enable-the-Required-GCP-APIs

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>