### PR TITLE
feat(azure): configure flexible subscription ids

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -1,17 +1,19 @@
-# Azure Provisioning - Step By Step
-This document describes the step-by-step process to connect Lacework with Azure Cloud. This code
-creates the required resources for Azure Compliance assessment, as well as Azure Activity Log
-Trail analysis.
+# Lacework Terraform Provisioning for Azure
+Terraform modules that create Azure resources required to integrate Azure Tenants and Subscriptions
+with the Lacework Cloud Security Platform.
 
 ## Requirements
-- Terraform `v.0.12.x`
+Before using these modules you must meet the following requirements:
+
+- [Terraform](terraform.io/downloads.html) `v0.12.x`
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
 - [Azure User](https://cloud.google.com/iam/docs/service-accounts) with the following permissions:
   - *Global Administrator* privileges in Active Directory
   - *Owner Role* at the Subscription level
 - [Lacework API Key](https://support.lacework.com/hc/en-us/articles/360011403853-Generate-API-Access-Keys-and-Tokens) 
 
-Also recommend that the [Lacework CLI](https://github.com/lacework/go-sdk/wiki/CLI-Documentation) be installed and the `[default]` profile is associated with the applicable Lacework Account `api_key` and `api_secret` in `~/.lacework.toml`
+We also recommend that the [Lacework CLI](https://github.com/lacework/go-sdk/wiki/CLI-Documentation) is installed and the `[default]`
+profile is associated with the applicable Lacework Account `api_key` and `api_secret` inside the `~/.lacework.toml` configuration file.
 
 ## Login via the Azure CLI
 In order to integrate Lacework with Azure you will need to login to your Azure console via
@@ -55,8 +57,10 @@ module "az_activity_log" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| application_name | The name of the Azure Active Directory Applicaiton | `string` | lacework_security_audit | no |
+| application_name | The name of the Azure Active Directory Application | `string` | lacework_security_audit | no |
 | application_identifier_uris | A list of user-defined URI(s) for the Lacework AD Application | `list(string)` | ["https://securityaudit.lacework.net"] | no |
+| subscription_ids | A list of subscriptions to grant read access to, by default the modules will only use the primary subscription | `list(string)` | `[]` | no |
+| all_subscriptions | If set to true, grant read access to ALL subscriptions within the selected Tenant (overrides `subscription_ids`) | `bool` | false | no |
 | key_vault_ids | A list of Key Vault Ids used in your subscription for the Lacework AD App to have access to | `list(string)` | [] | no |
 | tenant_id | A Tenant ID different from the default defined inside the provider | `string` | "" | no |
 | password_length | The length of the Lacework AD Application password | `number` | 30 | no |

--- a/azure/modules/activity_log/main.tf
+++ b/azure/modules/activity_log/main.tf
@@ -9,6 +9,8 @@ module "az_al_ad_application" {
   create                      = var.use_existing_ad_application ? false : true
   application_name            = var.application_name
   application_identifier_uris = var.application_identifier_uris
+  subscription_ids            = var.subscription_ids
+  all_subscriptions           = var.all_subscriptions
   key_vault_ids               = var.key_vault_ids
   tenant_id                   = var.tenant_id
   password_length             = var.password_length

--- a/azure/modules/activity_log/variables.tf
+++ b/azure/modules/activity_log/variables.tf
@@ -28,6 +28,18 @@ variable "application_identifier_uris" {
   ]
 }
 
+variable "subscription_ids" {
+  type        = list(string)
+  description = "List of subscriptions to grant read access to, by default the module will only use the primary subscription"
+  default     = []
+}
+
+variable "all_subscriptions" {
+  type        = bool
+  default     = false
+  description = "If set to true, grant read access to ALL subscriptions within the selected Tenant (overrides 'subscription_ids')"
+}
+
 # If some of the subscriptions use Key Vault services, we need to the
 # Azure App to have access to each Key Vault used in your subscriptions.
 variable "key_vault_ids" {

--- a/azure/modules/ad_application/examples/all-subscriptions-ad-application/main.tf
+++ b/azure/modules/ad_application/examples/all-subscriptions-ad-application/main.tf
@@ -1,0 +1,10 @@
+provider "azuread" {}
+
+provider "azurerm" {
+  features {}
+}
+
+module "ad_application" {
+  source            = "../../"
+  all_subscriptions = true
+}

--- a/azure/modules/ad_application/examples/custom-ad-application/main.tf
+++ b/azure/modules/ad_application/examples/custom-ad-application/main.tf
@@ -9,6 +9,7 @@ module "ad_application" {
   application_name            = "lacework_custom_ad_application_name"
   application_identifier_uris = ["https://account.lacework.net"]
   key_vault_ids               = ["vault-id-1", "vault-id-2", "vault-id-3", "vault-id-4"]
+  subscription_ids            = ["subscription-id-1", "subscription-id-2", "subscription-id-3"]
   tenant_id                   = "123abc12-abcd-1234-abcd-abcd12340123"
   password_lenght             = 16
 }

--- a/azure/modules/ad_application/variables.tf
+++ b/azure/modules/ad_application/variables.tf
@@ -4,10 +4,22 @@ variable "create" {
   description = "Set to false to prevent the module from creating any resources"
 }
 
+variable "subscription_ids" {
+  type        = list(string)
+  description = "List of subscriptions to grant read access to, by default the module will only use the primary subscription"
+  default     = []
+}
+
+variable "all_subscriptions" {
+  type        = bool
+  default     = false
+  description = "If set to true, grant read access to ALL subscriptions within the selected Tenant (overrides 'subscription_ids')"
+}
+
 variable "application_name" {
   type        = string
   default     = "lacework_security_audit"
-  description = "The name of the Azure Active Directory Applicaiton"
+  description = "The name of the Azure Active Directory Application"
 }
 
 variable "tenant_id" {

--- a/azure/modules/config/examples/custom-config/main.tf
+++ b/azure/modules/config/examples/custom-config/main.tf
@@ -11,6 +11,7 @@ module "az_config" {
   application_name            = "lacework_custom_ad_application_name"
   application_identifier_uris = ["https://account.lacework.net"]
   key_vault_ids               = ["vault-id-1", "vault-id-2", "vault-id-3", "vault-id-4"]
+  subscription_ids            = ["subscription-id-1", "subscription-id-2", "subscription-id-3"]
   tenant_id                   = "123abc12-abcd-1234-abcd-abcd12340123"
   lacework_integration_name   = "a custom name"
   password_lenght             = 16

--- a/azure/modules/config/examples/default-config/main.tf
+++ b/azure/modules/config/examples/default-config/main.tf
@@ -4,11 +4,8 @@ provider "azurerm" {
   features {}
 }
 
-provider "lacework" {
-  #profile = "mini"
-}
+provider "lacework" {}
 
 module "az_config" {
   source = "../../"
-  #application_identifier_uris = ["https://mini-ally.lacework.net"]
 }

--- a/azure/modules/config/main.tf
+++ b/azure/modules/config/main.tf
@@ -8,6 +8,8 @@ module "az_cfg_ad_application" {
   create                      = var.use_existing_ad_application ? false : true
   application_name            = var.application_name
   application_identifier_uris = var.application_identifier_uris
+  subscription_ids            = var.subscription_ids
+  all_subscriptions           = var.all_subscriptions
   key_vault_ids               = var.key_vault_ids
   tenant_id                   = var.tenant_id
   password_length             = var.password_length

--- a/azure/modules/config/variables.tf
+++ b/azure/modules/config/variables.tf
@@ -13,6 +13,18 @@ variable "application_identifier_uris" {
   ]
 }
 
+variable "subscription_ids" {
+  type        = list(string)
+  description = "List of subscriptions to grant read access to, by default the module will only use the primary subscription"
+  default     = []
+}
+
+variable "all_subscriptions" {
+  type        = bool
+  default     = false
+  description = "If set to true, grant read access to ALL subscriptions within the selected Tenant (overrides 'subscription_ids')"
+}
+
 # If some of the subscriptions use Key Vault services, we need to the
 # Azure App to have access to each Key Vault used in your subscriptions.
 variable "key_vault_ids" {


### PR DESCRIPTION
We have introduced the following behavior when choosing which
subscriptions to grant read access to:

* By default, we grant access to only the primary subscription
* If the user prefers to, they can provide a list of subscriptions to grant read access to
* Finally, users can also opt to grant read access to ALL subscriptions within a tenant

New inputs:

| Name | Description | Type | Default | Required |
|------|-------------|------|---------|:--------:|
| subscription_ids | A list of subscriptions to grant read access to, by default the modules will only use the primary subscription | `list(string)` | `[]` | no |
| all_subscriptions | If set to true, grant read access to ALL subscriptions within the selected Tenant (overrides `subscription_ids`) | `bool` | false | no |

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>