### PR TITLE
docs(azure): pin azurerm provider to 2.26

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -41,6 +41,7 @@ our [latest releases](https://github.com/lacework/terraform-provisioning/release
 provider "azuread" {}
 
 provider "azurerm" {
+  version = "2.26"
   features {}
 }
 


### PR DESCRIPTION
Updating example in main Azure README to pin azurerm provider at 2.26 to address bug in the provider. 

https://github.com/terraform-providers/terraform-provider-azurerm/issues/8426


Signed-off-by: Scott Ford <scott.ford@lacework.net>