### PR TITLE
docs(azure) Update docs for exiting Azure shell instead of restart

### DIFF
--- a/azure/AZURE_CLOUD_SHELL.md
+++ b/azure/AZURE_CLOUD_SHELL.md
@@ -27,7 +27,8 @@ script to install all the neccessary tools and configure some environment variab
 PS /home/salim> curl https://raw.githubusercontent.com/lacework/terraform-provisioning/master/azure/shell_startup.sh | bash
 ```
 
-Make sure to restart your shell before proceeding to the next step.
+When the script completes you need to type `exit` followed by enter to exit your shell. After a few seconds you will 
+be prompted to reconnect to your shell. Once reconnected, the Lacework CLI will be ready for use. 
 
 ## Configure the Lacework CLI
 

--- a/azure/shell_startup.sh
+++ b/azure/shell_startup.sh
@@ -37,4 +37,4 @@ else
 fi
 
 echo ""
-echo "Your shell is almost ready, please restart your terminal before running any Lacework CLI command!"
+echo "Your shell is almost ready. Type `exit` then hit enter before running any Lacework CLI command. You will then be prompted to 'reconnect' to your shell"


### PR DESCRIPTION
This change updates the Azure shell docs and the script to provide a clearer message to `exit` the current shell rather than restarting the the shell, as a restart removes the installation of the CLI and TF v.0.12.x

Signed-off-by: Scott Ford <scott.ford@lacework.net>