### PR TITLE
docs(gcp) Update GCP Cloud Shell docs to exit shell

### DIFF
--- a/azure/shell_startup.sh
+++ b/azure/shell_startup.sh
@@ -37,4 +37,4 @@ else
 fi
 
 echo ""
-echo "Your shell is almost ready. Type `exit` then hit enter before running any Lacework CLI command. You will then be prompted to 'reconnect' to your shell"
+echo "Your shell is almost ready. Type 'exit' then hit enter before running any Lacework CLI command. You will then be prompted to 'reconnect' to your shell"

--- a/gcp/GOOGLE_CLOUD_SHELL.md
+++ b/gcp/GOOGLE_CLOUD_SHELL.md
@@ -31,7 +31,8 @@ variables required by Terraform.
 afiune@cloudshell:~ $ curl https://raw.githubusercontent.com/lacework/terraform-provisioning/master/gcp/shell_startup.sh | bash
 ```
 
-Make sure to open a new terminal or restart your shell before proceeding to the next step.
+When the script completes you need to type `exit` followed by enter to exit your shell. Once the shell has exited you can open 
+the Cloud Shell again and the Lacework CLI will be ready for use!
 
 ## Configure the Lacework CLI
 

--- a/gcp/shell_startup.sh
+++ b/gcp/shell_startup.sh
@@ -20,4 +20,4 @@ if [ ! -f "$HOME/bin/terraform" ]; then
 fi
 
 echo ""
-echo "Your shell is almost ready. Type `exit` then hit enter before running any Lacework CLI command. Open the Cloud Shell again and the Lacework CLI will be ready for use!"
+echo "Your shell is almost ready. Type 'exit' then hit enter before running any Lacework CLI command. Open the Cloud Shell again and the Lacework CLI will be ready for use!"

--- a/gcp/shell_startup.sh
+++ b/gcp/shell_startup.sh
@@ -20,4 +20,4 @@ if [ ! -f "$HOME/bin/terraform" ]; then
 fi
 
 echo ""
-echo "Your shell is almost ready, please restart your terminal before running any Lacework CLI command!"
+echo "Your shell is almost ready. Type `exit` then hit enter before running any Lacework CLI command. Open the Cloud Shell again and the Lacework CLI will be ready for use!"


### PR DESCRIPTION
This PR updates GCP Cloud Shell docs to explicitly state to `exit` shell rather than "restart" the shell, which mirrors our Azure Shell docs.

Signed-off-by: Scott Ford <scott.ford@lacework.net>