### PR TITLE
ci: add Terraform 13 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
-FROM hashicorp/terraform:0.12.29
+# This images is used to test our Terraform Provider and Modules
+#
+# Repo: techallylw/terraform
+# URL: https://hub.docker.com/r/techallylw/terraform
 
-RUN apk update && apk add bash
+# Tag: 12
+FROM hashicorp/terraform:0.12.29 AS terraform12
+RUN apk update
+RUN apk add bash
+RUN apk add curl
+
+# Tag: 13
+FROM hashicorp/terraform:0.13.4 AS terraform13
+RUN apk update
+RUN apk add bash
+RUN apk add curl


### PR DESCRIPTION
This image is being used by all our Terraform Modules and Provider!

Example: https://github.com/lacework/terraform-aws-config/pull/3

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>