### PR TITLE
fix(azure): update shell_startup.sh to use Terraform 13

### DIFF
--- a/azure/shell_startup.sh
+++ b/azure/shell_startup.sh
@@ -2,38 +2,69 @@
 
 set -e
 
+echo "-> Running the Lacework Cloud Shell startup script"
+
 # Create a custom bin/ directory
 mkdir -p $HOME/bin
 
 # Install the Lacework CLI if it is not installed
 if [ ! -f "$HOME/bin/lacework" ]; then
+    echo "-> Installing the Lacework CLI..."
     curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash -s -- -d $HOME/bin
+else
+    echo "-> The Lacework CLI is already installed!"
+    lacework version
 fi
 
-# Install Terraform if it is not installed
-if [ ! -f "$HOME/bin/terraform" ]; then
-    curl https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip --output $HOME/bin/terraform.zip
-    unzip $HOME/bin/terraform.zip -d $HOME/bin
-    rm $HOME/bin/terraform.zip
-fi
-
-# Export required Terraform environment variables
+# Export required environment variables
 if [ -z $PSModulePath ]; then
-    echo "Setting up your Bash prompt."
+    echo "-> Setting up your Bash prompt..."
     lw_env="$HOME/.lw_env"
     echo 'export PATH="$HOME/bin:$PATH"' > $lw_env
-    echo 'export ARM_SUBSCRIPTION_ID=$(az account show --output=json | jq -r -M ".id")' >> $lw_env
-    echo 'export ARM_TENANT_ID=$(az account show --output=json | jq -r -M ".tenantId")' >> $lw_env
-    echo 'export ARM_USE_MSI=true' >> $lw_env
     echo "source .lw_env" >> .bashrc
 else
-    echo "Setting up your Powershell prompt."
+    echo "-> Setting up your Powershell prompt..."
     powershell_profile="$HOME/.config/PowerShell/Microsoft.PowerShell_profile.ps1"
     mkdir -p $HOME/.config/PowerShell/
     echo '$env:PATH="$env:HOME/bin:$env:PATH"' > $powershell_profile
-    echo '$env:ARM_SUBSCRIPTION_ID=az account show --output=json | jq -r -M ".id"' >> $powershell_profile
-    echo '$env:ARM_TENANT_ID=az account show --output=json | jq -r -M ".tenantId"' >> $powershell_profile
-    echo '$env:ARM_USE_MSI="true"' >> $powershell_profile
+fi
+
+echo -n "-> Verifying that your user has the Global Administrator role... "
+export USER_ID=$(az ad signed-in-user show --output=json | jq -r -M '.objectId')
+export GLOBAL_ADMIN_ID=$(az rest --method get --url https://graph.microsoft.com/v1.0/directoryRoles | jq -r -M '.value[] | select(.displayName | contains("Company Administrator")) | .id')
+export GLOBAL_ADMIN_MEMBER=$(az rest --method get --url https://graph.microsoft.com/v1.0/directoryRoles/${GLOBAL_ADMIN_ID}/members)
+
+if [[ $GLOBAL_ADMIN_MEMBER == *"$USER_ID"* ]]; then
+  echo "SUCCESS!"
+else
+  echo "Not Found!"
+  echo ""
+  echo "ERROR: You do NOT have the required role 'Global Administrator', the following people have it:"
+  echo ""
+  echo $GLOBAL_ADMIN_MEMBER | jq -r -M '.value[] | "  * \(.displayName) <\(.userPrincipalName)>"'
+  exit 1
+fi
+
+echo "-> Verifying the Subscriptions that you have access to:"
+export SUBSCRIPTION_ID=`az account show --output=json | jq -r -M '.id'`
+echo ""
+az account list --output table
+echo ""
+echo -n "-> Verifying that your user has the Owner role for the Subscriptions ID '$SUBSCRIPTION_ID'... "
+export SUBSCRIPTION_ROLE=$(az role assignment list --subscription $SUBSCRIPTION_ID --output json --query '[].{id:principalId, name:roleDefinitionName}' | jq -r -M '.[] | select(.id | contains("'$USER_ID'")) | .name')
+if [[ "$SUBSCRIPTION_ROLE" == "Owner" ]]; then
+  echo "SUCCESS!"
+  echo ""
+  echo "-> IMPORTANT: All the resources will be created in your default Subscription '$SUBSCRIPTION_ID'."
+  echo "              To switch to a different Subscription run the following command:"
+  echo ""
+  echo "              az account set --subscription [ID]"
+else
+  echo "Not Found!"
+  echo ""
+  echo "ERROR: You do NOT have the required role 'Owner' for the Subscription '$SUBSCRIPTION_ID'."
+  echo "       The role found was '$SUBSCRIPTION_ROLE'. Try to switch to a different subscription."
+  exit 1
 fi
 
 echo ""


### PR DESCRIPTION
This PR is updating the `shell_startup.sh` script to use the default version of Terraform that comes from the Cloud Shell which is 13.X, additionally, we are adding extra checks to verify the required privileges of the user running this automation.

When a user doesn't have the Global Admin role, they will see the following output:

<img width="902" alt="Screen Shot 2020-11-06 at 2 01 49 AM" src="https://user-images.githubusercontent.com/5712253/98313457-223bde80-1f91-11eb-9d39-935e51b00378.png">

If the user has all the required permissions, they will see the following output:
![image](https://user-images.githubusercontent.com/5712253/98313614-7941b380-1f91-11eb-8ce8-03881d999c8e.png)


Signed-off-by: Salim Afiune Maya <afiune@lacework.net>