### PR TITLE
fix(azure): added unique suffix to Azure resources

### DIFF
--- a/azure/modules/activity_log/variables.tf
+++ b/azure/modules/activity_log/variables.tf
@@ -23,9 +23,7 @@ variable "application_name" {
 variable "application_identifier_uris" {
   type        = list(string)
   description = "A list of user-defined URI(s) for the Lacework AD Application"
-  default = [
-    "https://securityaudit.lacework.net"
-  ]
+  default     = []
 }
 
 variable "subscription_ids" {

--- a/azure/modules/activity_log/variables.tf
+++ b/azure/modules/activity_log/variables.tf
@@ -4,12 +4,12 @@ variable "location" {
   default     = "West US 2"
 }
 
-# NOTE: this prefix is used in all resources and we have a limitatino with the
+# NOTE: this prefix is used in all resources and we have a limitation with the
 # storage name that can only consist of lowercase letters and numbers, and must
 # be between 3 and 24 characters long
 variable "prefix" {
   type        = string
-  default     = "l4c3w0rk"
+  default     = "lacework"
   description = "The prefix that will be use at the beginning of every generated resource"
 }
 

--- a/azure/modules/ad_application/variables.tf
+++ b/azure/modules/ad_application/variables.tf
@@ -46,7 +46,5 @@ variable "key_vault_ids" {
 variable "application_identifier_uris" {
   type        = list(string)
   description = "A list of user-defined URI(s) for the Lacework AD Application"
-  default = [
-    "https://securityaudit.lacework.net"
-  ]
+  default     = []
 }

--- a/azure/modules/config/variables.tf
+++ b/azure/modules/config/variables.tf
@@ -8,9 +8,7 @@ variable "application_name" {
 variable "application_identifier_uris" {
   type        = list(string)
   description = "A list of user-defined URI(s) for the Lacework AD Application"
-  default = [
-    "https://securityaudit.lacework.net"
-  ]
+  default     = []
 }
 
 variable "subscription_ids" {


### PR DESCRIPTION
- Added unique suffix to Azure resources
- Updated 'azurerm_role_definition.lacework.id' to 'azurerm_role_definition.lacework.role_definition_resource_id'  (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment#example-usage-custom-role--service-principal)
- Changed default prefix from 'l4c3w0rk' to 'lacework'