### PR TITLE
feat(gcp): upgrade terraform inside shell_startup.sh

### DIFF
--- a/gcp/shell_startup.sh
+++ b/gcp/shell_startup.sh
@@ -14,7 +14,7 @@ fi
 
 # Install Terraform if it is not installed
 if [ ! -f "$HOME/bin/terraform" ]; then
-    curl https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip --output $HOME/bin/terraform.zip
+    curl https://releases.hashicorp.com/terraform/0.14.4/terraform_0.14.4_linux_amd64.zip --output $HOME/bin/terraform.zip
     unzip $HOME/bin/terraform.zip -d $HOME/bin
     rm $HOME/bin/terraform.zip
 fi

--- a/gcp/shell_startup.sh
+++ b/gcp/shell_startup.sh
@@ -9,7 +9,11 @@ mkdir -p $HOME/bin
 
 # Install the Lacework CLI if it is not installed
 if [ ! -f "$HOME/bin/lacework" ]; then
+    echo "-> Installing the Lacework CLI..."
     curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash -s -- -d $HOME/bin
+else
+    echo "-> The Lacework CLI is already installed!"
+    lacework version
 fi
 
 # Install Terraform if it is not installed


### PR DESCRIPTION
Azure Cloud Shells are always up-to-date to provision VMs with the latest
version of Terraform, but Google Cloud Shell are not, so we are installing
the latest version for our users.

Current Version on Google Cloud Shell VMs:

![image](https://user-images.githubusercontent.com/5712253/104319061-91581680-549d-11eb-8ca8-cdff490ccefb.png)
