### PR TITLE
fix(azure): Microsoft role rename in shell_startup.sh

### DIFF
--- a/azure/shell_startup.sh
+++ b/azure/shell_startup.sh
@@ -31,7 +31,7 @@ fi
 
 echo -n "-> Verifying that your user has the Global Administrator role... "
 export USER_ID=$(az ad signed-in-user show --output=json | jq -r -M '.objectId')
-export GLOBAL_ADMIN_ID=$(az rest --method get --url https://graph.microsoft.com/v1.0/directoryRoles | jq -r -M '.value[] | select(.displayName | contains("Company Administrator")) | .id')
+export GLOBAL_ADMIN_ID=$(az rest --method get --url https://graph.microsoft.com/v1.0/directoryRoles | jq -r -M '.value[] | select(.displayName | contains("Global Administrator")) | .id')
 export GLOBAL_ADMIN_MEMBER=$(az rest --method get --url https://graph.microsoft.com/v1.0/directoryRoles/${GLOBAL_ADMIN_ID}/members)
 
 if [[ $GLOBAL_ADMIN_MEMBER == *"$USER_ID"* ]]; then


### PR DESCRIPTION
Well, Microsoft changed the Role name from `Company Administrator` to `Global Administrator`... Why Microsoft?

https://docs.microsoft.com/en-us/answers/questions/233909/get-azureaddirectoryrole-and-34global-administrato.html

![tenor-141429280](https://user-images.githubusercontent.com/5712253/111207535-5f435d80-858f-11eb-900d-d4a2975313d7.gif)

To test this modification run the following command on your Azure Cloud Shell:
```
curl https://raw.githubusercontent.com/lacework/terraform-provisioning/b4b87ebaf347f19f01ea7dff96d366cda72337ee/azure/shell_startup.sh | bash
```
<img width="1510" alt="Screen Shot 2021-03-15 at 1 08 44 PM" src="https://user-images.githubusercontent.com/5712253/111208063-e98bc180-858f-11eb-8dc2-423f1a0e24ed.png">
