### PR TITLE
fix: upgrade our Terraform docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,15 @@
 # URL: https://hub.docker.com/r/techallylw/terraform
 
 # Tag: 12
-FROM hashicorp/terraform:0.12.29 AS terraform12
+FROM hashicorp/terraform:0.12.31 AS terraform12
 RUN apk update
 RUN apk add bash
 RUN apk add curl
+RUN apk add make jq
 
 # Tag: 13
-FROM hashicorp/terraform:0.13.4 AS terraform13
+FROM hashicorp/terraform:0.13.7 AS terraform13
 RUN apk update
 RUN apk add bash
 RUN apk add curl
+RUN apk add make jq


### PR DESCRIPTION
From the Codecov breach, Hashicorp had to rotate their GPG key and with
that, they had to release a new version of their Terraform CLI:

https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570

We are upgrading the version of our containers to the recommended
version.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>