### PR TITLE
fix: azure shell startup script for multiple roles

### DIFF
--- a/azure/shell_startup.sh
+++ b/azure/shell_startup.sh
@@ -52,7 +52,7 @@ az account list --output table
 echo ""
 echo -n "-> Verifying that your user has the Owner role for the Subscriptions ID '$SUBSCRIPTION_ID'... "
 export SUBSCRIPTION_ROLE=$(az role assignment list --subscription $SUBSCRIPTION_ID --output json --query '[].{id:principalId, name:roleDefinitionName}' | jq -r -M '.[] | select(.id | contains("'$USER_ID'")) | .name')
-if [[ "$SUBSCRIPTION_ROLE" == "Owner" ]]; then
+if [[ "$SUBSCRIPTION_ROLE" == *"Owner"* ]]; then
   echo "SUCCESS!"
   echo ""
   echo "-> IMPORTANT: All the resources will be created in your default Subscription '$SUBSCRIPTION_ID'."


### PR DESCRIPTION
When a customer uses the shell_startup.sh script and
he/she has multiple roles assigned, the script doesn’t
handle this case well and says that the user doesn’t have
the Owner Role, even when he/she does have it.

JIRA: https://lacework.atlassian.net/browse/ALLY-563

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>