### PR TITLE
fix: attribute reference causing owner to not be identified

### DIFF
--- a/azure/shell_startup.sh
+++ b/azure/shell_startup.sh
@@ -33,7 +33,7 @@ else
 fi
 
 echo -n "-> Verifying that your user has the Global Administrator role... "
-export USER_ID=$(az ad signed-in-user show --output=json | jq -r -M '.objectId')
+export USER_ID=$(az ad signed-in-user show --output=json | jq -r -M '.id')
 export GLOBAL_ADMIN_ID=$(az rest --method get --url https://graph.microsoft.com/v1.0/directoryRoles | jq -r -M '.value[] | select(.displayName | contains("Global Administrator")) | .id')
 export GLOBAL_ADMIN_MEMBER=$(az rest --method get --url https://graph.microsoft.com/v1.0/directoryRoles/${GLOBAL_ADMIN_ID}/members)
 


### PR DESCRIPTION
We were trying to run this Script as the administrator/owner of the Azure tenant/subscription and we encountered errors. We had to switch the reference to be `.id` instead of `.objectId` as the `objectId` key did not exist and the value `null` was getting assigned when performing the Owner permissions User check. When we changed it to `.id`, the script began to function as we expected.