### PR TITLE
fix: include azure roles assigned via groups

### DIFF
--- a/azure/shell_startup.sh
+++ b/azure/shell_startup.sh
@@ -52,7 +52,7 @@ echo ""
 az account list --output table
 echo ""
 echo -n "-> Verifying that your user has the Owner role for the Subscriptions ID '$SUBSCRIPTION_ID'... "
-export SUBSCRIPTION_ROLE=$(az role assignment list --all --assignee $USER_ID --subscription $SUBSCRIPTION_ID --output json --query '[].{id:principalId, name:roleDefinitionName}' | jq -r -M '.[] | select(.id | contains("'$USER_ID'")) | .name')
+export SUBSCRIPTION_ROLE=$(az role assignment list --all --include-groups --assignee $USER_ID --subscription $SUBSCRIPTION_ID --output json --query '[].{id:principalId, name:roleDefinitionName}' | jq -r -M '.[].name')
 if [[ "$SUBSCRIPTION_ROLE" == *"Owner"* ]]; then
   echo "SUCCESS!"
   echo ""


### PR DESCRIPTION
Currently the script only gets roles that are assigned to the user directly.
Added the `--include-groups` flag so that it gets roles assigned via groups as well.
Also removed the jq select because the principalId will be that of the group, not the user.